### PR TITLE
Reducing RAM usage: using rtgtools-vcfeval multi-threading and launching samples sequentially + minor modifications

### DIFF
--- a/besolverd.py
+++ b/besolverd.py
@@ -69,9 +69,9 @@ def alignAndBenchMark(
         + bedtoolsExec
         + " intersect "
         + " -a stdin "
-        + " -b "
+        + " -b '"
         + refBedFile
-        + "   > "
+        + "'   > "
         + bedIntersect_file
     ]
     cmds += [

--- a/besolverd.py
+++ b/besolverd.py
@@ -200,6 +200,8 @@ def main(
 
     if mosdepthPath is not None:
         mosdepthExec = mosdepthPath + "/" + mosdepthExec
+    if bedtoolsPath is not None:
+        bedtoolsExec = bedtoolsPath + "/" + bedtoolsExec
     if rtgtoolsPath is not None:
         rtgtoolsExec = rtgtoolsPath + "/" + rtgtoolsExec
     if dataPath is None and not downloadReference:


### PR DESCRIPTION
- RTGtools vcfeval call now uses its multithreading -T option
- Each sample/threshold is launched sequentially
- Minor fixes:
   - Added quotes around refBedFile in one of the calls
   - Fixed the bedtoolsPath, which is now correctly being passed to all invocations of this binary
